### PR TITLE
Add tapms-operator namespace for cert management

### DIFF
--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.6.0
+version: 0.6.1
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager

--- a/charts/cray-certmanager-issuers/values.yaml
+++ b/charts/cray-certmanager-issuers/values.yaml
@@ -1,4 +1,27 @@
 #
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#
 # used to patch issuers with dynamic service
 # account secret name
 #
@@ -49,6 +72,13 @@ vaultIssuers:
     vaultK8SAuthPath: /v1/auth/kubernetes
   ceph-rgw-common:
     namespace: ceph-rgw
+    instance: common
+    vaultServer: "http://cray-vault.vault.svc.cluster.local:8200"
+    vaultPKIRole: pki-common
+    vaultPKIPath: pki_common/sign
+    vaultK8SAuthPath: /v1/auth/kubernetes
+  tapms-operator-common:
+    namespace: tapms-operator
     instance: common
     vaultServer: "http://cray-vault.vault.svc.cluster.local:8200"
     vaultPKIRole: pki-common


### PR DESCRIPTION
## Summary and Scope

Refactor namespaces controlled by hnc controller, create specific namespaces for tapms and slurm.

## Issues and Related PRs

* Resolves [CASMINST-4841](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4841)
* Resolves [CASMINST-4843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4843)

## Testing

```
multi-tenancy
├── slurm-operator
├── tapms-operator
└── tenants
    ├── [s] vcluster-coke
    │   └── [s] vcluster-coke-user
    └── [s] vcluster-pepsi
        └── [s] vcluster-pepsi-user

[s] indicates subnamespaces
```

```
ncn-m001-48d9c509:/home/bklein # kubectl get secrets -n slurm-operator
NAME                  TYPE                                  DATA   AGE
default-token-vt5br   kubernetes.io/service-account-token   3      4m2s
wlm-s3-credentials    Opaque                                7      2m23s
```


### Tested on:

  * Virtual Shasta

### Test description:

Installed/uninstalled the following charts in concert:

```
   - name: cray-drydock
     version: 2.14.5
     namespace: loftsman
   - name: cray-vault
     version: 1.3.6
     namespace: vault
   - name: cray-psp
     version: 0.4.3
     namespace: services
   - name: cray-certmanager-issuers
     version: 0.6.5
     namespace: cert-manager
   - name: cray-hnc-manager
     version: 0.0.1
     namespace: hnc-system
   - name: cray-tapms-operator
     version: 0.0.1
     namespace: tapms-operator
   - name: cray-sample-subtenant-operator
     version: 0.0.1
     namespace: tenants
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
