### PR TITLE
Add issuer for slurm-operator namespace

### DIFF
--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.6.1
+version: 0.6.2
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager

--- a/charts/cray-certmanager-issuers/values.yaml
+++ b/charts/cray-certmanager-issuers/values.yaml
@@ -21,7 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-#
 # used to patch issuers with dynamic service
 # account secret name
 #
@@ -79,6 +78,13 @@ vaultIssuers:
     vaultK8SAuthPath: /v1/auth/kubernetes
   tapms-operator-common:
     namespace: tapms-operator
+    instance: common
+    vaultServer: "http://cray-vault.vault.svc.cluster.local:8200"
+    vaultPKIRole: pki-common
+    vaultPKIPath: pki_common/sign
+    vaultK8SAuthPath: /v1/auth/kubernetes
+  slurm-operator-common:
+    namespace: slurm-operator
     instance: common
     vaultServer: "http://cray-vault.vault.svc.cluster.local:8200"
     vaultPKIRole: pki-common


### PR DESCRIPTION
## Summary and Scope

Fix for slurm-operator writing munge keys to vault from slurm-operator namespace -- add issuer for slurm-operator namespace.

## Issues and Related PRs

* Resolves [CASMPET-5953](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5953)

## Testing

```
ncn-m001-cdd6e862:/home/bklein/demo # kubectl get issuers.cert-manager.io -n slurm-operator -o wide

NAME                         READY   STATUS           AGE
cert-manager-issuer-common   True    Vault verified   34s
```

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

