### PR TITLE
Casmpet 6696 master

### DIFF
--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.6.2
+version: 0.6.3
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager
@@ -33,6 +33,6 @@ sources:
 maintainers:
   - name: kburns-hpe
 icon: https://github.com/jetstack/cert-manager/raw/master/logo/logo.png
-appVersion: 0.14.1
+appVersion: 1.5.5
 annotations:
   artifacthub.io/license: MIT

--- a/charts/cray-certmanager-issuers/README.md
+++ b/charts/cray-certmanager-issuers/README.md
@@ -27,34 +27,39 @@ vaultIssuers:
 Verify Issuer:
 
 ```
-# kubectl get issuer -n services -o yaml
+# kubectl get issuer --namespace services -o yaml
 apiVersion: v1
 items:
-- apiVersion: cert-manager.io/v1alpha3
+- apiVersion: cert-manager.io/v1
   kind: Issuer
   metadata:
-    creationTimestamp: "2020-04-23T13:53:13Z"
+    annotations:
+      meta.helm.sh/release-name: cray-certmanager-issuers
+      meta.helm.sh/release-namespace: cert-manager
+    creationTimestamp: "2023-07-14T19:48:04Z"
     generation: 2
+    labels:
+      app.kubernetes.io/managed-by: Helm
     name: cert-manager-issuer-common
     namespace: services
-    resourceVersion: "1066339"
-    selfLink: /apis/cert-manager.io/v1alpha3/namespaces/services/issuers/cert-manager-issuer-common
-    uid: 1c0bfb27-00e4-4732-9984-9d15e9d5fd24
+    resourceVersion: "13203"
+    uid: c8cf6ee6-7eee-4f13-b25b-0d428865b511
   spec:
     vault:
       auth:
         kubernetes:
           mountPath: /v1/auth/kubernetes
-          role: common
+          role: pki-common
           secretRef:
             key: token
-            name: cert-manager-issuer-common-token-plhw2
-      path: pki_common/sign/common
+            name: cert-manager-issuer-common-token-58hnr
+      path: pki_common/sign/pki-common
       server: http://cray-vault.vault.svc.cluster.local:8200
   status:
     conditions:
-    - lastTransitionTime: "2020-04-23T13:53:18Z"
+    - lastTransitionTime: "2023-07-14T19:48:14Z"
       message: Vault verified
+      observedGeneration: 2
       reason: VaultVerified
       status: "True"
       type: Ready
@@ -67,7 +72,7 @@ metadata:
 Manifest you can use to create a certificate against a named cert-manager issuer:
 
 ```
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: istio-ingress
@@ -108,7 +113,7 @@ Verify the certificate is ready:
 
 ```
 # kubectl get certificate -n services istio-ingress -o yaml
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   creationTimestamp: "2020-04-23T14:21:32Z"
@@ -116,7 +121,7 @@ metadata:
   name: istio-ingress
   namespace: services
   resourceVersion: "1083056"
-  selfLink: /apis/cert-manager.io/v1alpha3/namespaces/services/certificates/istio-ingress
+  selfLink: /apis/cert-manager.io/v1/namespaces/services/certificates/istio-ingress
   uid: 7777b471-85fb-4c5a-a60b-05b65f25fa33
 spec:
   commonName: istio-public-ingress.example.com

--- a/charts/cray-certmanager-issuers/templates/vault-issuers.yaml
+++ b/charts/cray-certmanager-issuers/templates/vault-issuers.yaml
@@ -13,7 +13,7 @@ metadata:
 # Create a vault issuer. The secretRef name will
 # be patched later, and will not initially be valid
 #
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: cert-manager-issuer-{{ .instance }}


### PR DESCRIPTION
## Summary and Scope

For 1.5.5+ cert-manager we only want to use /v/1 apis. Remove the last vestige and usage of non /v1/ cert-manager api usage in the cray-certmanager-issuers chart.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Running on dorian

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta dorian

### Test description:

Installed/upgaded on dorian to ensure new issuers still worked.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

n/a the issuers api usage here required zero changes to /v1/ due to it not actually using any changed components.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

