### PR TITLE
CASMPET-6904 update cert-manager to 1.12.9

### DIFF
--- a/charts/cray-certmanager-issuers/CHANGELOG.md
+++ b/charts/cray-certmanager-issuers/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the `cray-certmanager-issuers` chart, indexed by semantic versions.
 
+## v0.7.0
+
+- Upgrade cert-manager to v1.12.9
+
 ## v0.4.0 
 
 - Add common issuer to ceph-rgw namespace (CASMSEC-206)

--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.6.3
+version: 0.7.0
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager
@@ -33,6 +33,6 @@ sources:
 maintainers:
   - name: kburns-hpe
 icon: https://github.com/jetstack/cert-manager/raw/master/logo/logo.png
-appVersion: 1.5.5
+appVersion: 1.12.9
 annotations:
   artifacthub.io/license: MIT

--- a/charts/cray-certmanager/CHANGELOG.md
+++ b/charts/cray-certmanager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the `cray-certmanager` chart, indexed by semantic versions.
 
+##v0.8.0
+
+- Upgrade cert-manager to v1.12.9
+
 ##v0.7.0
 
 - Removed cray-certmanager-init

--- a/charts/cray-certmanager/Chart.yaml
+++ b/charts/cray-certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-certmanager
-version: 0.7.3
+version: 0.8.0
 description: Support for managing PKI certificates and associated key material inside k8s
 keywords:
   - cert-manager
@@ -9,13 +9,13 @@ sources:
   - https://github.com/jetstack/cert-manager
 dependencies:
   - name: cert-manager
-    version: v1.5.5
+    version: v1.12.9
     repository: https://charts.jetstack.io
 maintainers:
   - name: kburns-hpe
   - name: mitchty
 icon: https://github.com/jetstack/cert-manager/raw/master/logo/logo.png
-appVersion: 1.5.5
+appVersion: 1.12.9
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -29,11 +29,11 @@ annotations:
     - name: curl
       image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
     - name: cert-manager-cainjector
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.5.5
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.12.9
     - name: cert-manager-ctl
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.5.5
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.12.9
     - name: cert-manager-controller
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.5.5
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.12.9
     - name: cert-manager-webhook
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.5.5
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.12.9
   artifacthub.io/license: MIT

--- a/charts/cray-certmanager/values.yaml
+++ b/charts/cray-certmanager/values.yaml
@@ -32,6 +32,9 @@ cert-manager:
                   values:
                     - cert-manager
             topologyKey: kubernetes.io/hostname
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile: null
   extraArgs:
     - "--enable-certificate-owner-ref=true"
   webhook:
@@ -53,6 +56,9 @@ cert-manager:
                       - webhook
               topologyKey: kubernetes.io/hostname
     serviceName: cray-certmanager-cert-manager-webhook
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile: null
   cainjector:
     image:
       registry: artifactory.algol60.net
@@ -71,12 +77,18 @@ cert-manager:
                     values:
                       - cainjector
               topologyKey: kubernetes.io/hostname
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile: null
   startupapicheck:
     podAnnotations:
       "sidecar.istio.io/inject": "false"
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/jetstack/cert-manager-ctl
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile: null
 # Not actively ran just used in a k8s job to upgrade existing resources.
 ctl:
   image:


### PR DESCRIPTION
## Summary and Scope

Update cert-manager to 1.12.9. This is a required update in order for our k8s upgrade in CSM 1.6.

I have tested this on Beau. More substantial testing will be done before updating the CSM manifest with this version.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

