### PR TITLE
CASMPET-6904-v2 enable pod security policy

### DIFF
--- a/charts/cray-certmanager/CHANGELOG.md
+++ b/charts/cray-certmanager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the `cray-certmanager` chart, indexed by semantic versions.
 
+##v0.8.1
+
+- Enable PodSecurityPolicy so that chart can be upgraded during CSM 1.5 to CSM 1.6 upgrade.
+
 ##v0.8.0
 
 - Upgrade cert-manager to v1.12.9

--- a/charts/cray-certmanager/Chart.yaml
+++ b/charts/cray-certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-certmanager
-version: 0.8.0
+version: 0.8.1
 description: Support for managing PKI certificates and associated key material inside k8s
 keywords:
   - cert-manager

--- a/charts/cray-certmanager/values.yaml
+++ b/charts/cray-certmanager/values.yaml
@@ -14,6 +14,13 @@ cert-manager:
 
   global:
     logLevel: 6
+    podSecurityPolicy:
+      # Create PodSecurityPolicy for cert-manager.
+      #
+      # Note that PodSecurityPolicy was deprecated in Kubernetes 1.21 and removed in Kubernetes 1.25.
+      enabled: true
+      # Configure the PodSecurityPolicy to use AppArmor.
+      useAppArmor: true
 
   image:
     registry: artifactory.algol60.net
@@ -32,9 +39,6 @@ cert-manager:
                   values:
                     - cert-manager
             topologyKey: kubernetes.io/hostname
-  securityContext:
-    runAsNonRoot: true
-    seccompProfile: null
   extraArgs:
     - "--enable-certificate-owner-ref=true"
   webhook:
@@ -56,9 +60,6 @@ cert-manager:
                       - webhook
               topologyKey: kubernetes.io/hostname
     serviceName: cray-certmanager-cert-manager-webhook
-    securityContext:
-      runAsNonRoot: true
-      seccompProfile: null
   cainjector:
     image:
       registry: artifactory.algol60.net
@@ -77,18 +78,12 @@ cert-manager:
                     values:
                       - cainjector
               topologyKey: kubernetes.io/hostname
-    securityContext:
-      runAsNonRoot: true
-      seccompProfile: null
   startupapicheck:
     podAnnotations:
       "sidecar.istio.io/inject": "false"
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/jetstack/cert-manager-ctl
-    securityContext:
-      runAsNonRoot: true
-      seccompProfile: null
 # Not actively ran just used in a k8s job to upgrade existing resources.
 ctl:
   image:


### PR DESCRIPTION
## Summary and Scope

When testing an upgrade of cert-manager during a CSM 1.5 to CSM 1.6 upgrade, cert-manager failed to upgrade with the following error.

```
message: 'pods "cray-certmanager-cert-manager-6b757c6c68-" is forbidden: PodSecurityPolicy:
      unable to admit pod: [pod.metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]:
      Forbidden: seccomp may not be set
```

The podSecurityPolicy has to be enabled so that a PSP is created for cert-manager and will allow the default seccompProfile.

This will be tested on vshasta fresh install and upgrade before updating the CSM manifest.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

