### PR TITLE
CASMPET-7221 update certmanager-issuer by removing docker-kubectl from values.yaml

### DIFF
--- a/charts/cray-certmanager-issuers/CHANGELOG.md
+++ b/charts/cray-certmanager-issuers/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changes to the `cray-certmanager-issuers` chart, indexed by semantic versions.
 
+## v0.7.2
+
+- Update cray-certmanager-issuers by removing docker-kubectl image from values.yaml.
+This is no longer needed because the patch script to set issuer secretRef is no longer used with cert-manager v1.12.9.
+
 ## v0.7.1
 
 - Upgrade cray-certmanager-issuers to authenticate with kubernetes service accounts for k8s 1.24

--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.7.1
+version: 0.7.2
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager

--- a/charts/cray-certmanager-issuers/values.yaml
+++ b/charts/cray-certmanager-issuers/values.yaml
@@ -21,15 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# used to patch issuers with dynamic service
-# account secret name
-#
-
-kubectl:
-  image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
-    pullPolicy: IfNotPresent
 
 # Chart only deploys vault-backed issuers (e.g., no
 # self-signed currently). All values shown are required.


### PR DESCRIPTION
## Summary and Scope

Update certmanager-issuer by removing docker-kubectl from values.yaml. This is no longer needed becasue the patch script to set issuer secretRef is no longer used with cert-manager v1.12.9. In the new cert-manager version, secretRef is not used and instead tokens are gotten from the serviceAccount.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau (vshasta2)

### Test description:

Upgraded the cert-manager-issuers helm chart.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

