### PR TITLE
CASMPET-7368: Update cray-certmanager to v1.17.0

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -14,7 +14,7 @@ jobs:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false
       scan-chart-snyk-args: "--severity-threshold=high --policy-path=charts/.snyk"
-      #scan-image-snyk-args: "--severity-threshold=high"
+      scan-image-snyk-args: "--severity-threshold=high"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/cray-certmanager-issuers/CHANGELOG.md
+++ b/charts/cray-certmanager-issuers/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the `cray-certmanager-issuers` chart, indexed by semantic versions.
 
+## v0.8.0
+
+- Upgrade cert-manager to v1.17.0
+
 ## v0.7.2
 
 - Update cray-certmanager-issuers by removing docker-kubectl image from values.yaml.

--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/cray-certmanager-issuers/Chart.yaml
+++ b/charts/cray-certmanager-issuers/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-certmanager-issuers
-version: 0.7.2
+version: 0.8.0
 description: cert-manager per-namespace issuer setup
 keywords:
   - cert-manager
@@ -33,6 +33,6 @@ sources:
 maintainers:
   - name: kburns-hpe
 icon: https://github.com/jetstack/cert-manager/raw/master/logo/logo.png
-appVersion: 1.12.9
+appVersion: 1.17.0
 annotations:
   artifacthub.io/license: MIT

--- a/charts/cray-certmanager/CHANGELOG.md
+++ b/charts/cray-certmanager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changes to the `cray-certmanager` chart, indexed by semantic versions.
 
+##v0.9.0
+
+- Upgrade cert-manager to v1.17.0
+
 ##v0.8.1
 
 - Enable PodSecurityPolicy so that chart can be upgraded during CSM 1.5 to CSM 1.6 upgrade.

--- a/charts/cray-certmanager/Chart.yaml
+++ b/charts/cray-certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-certmanager
-version: 0.8.1
+version: 0.9.0
 description: Support for managing PKI certificates and associated key material inside k8s
 keywords:
   - cert-manager
@@ -9,13 +9,13 @@ sources:
   - https://github.com/jetstack/cert-manager
 dependencies:
   - name: cert-manager
-    version: v1.12.9
+    version: v1.17.0
     repository: https://charts.jetstack.io
 maintainers:
   - name: kburns-hpe
   - name: mitchty
 icon: https://github.com/jetstack/cert-manager/raw/master/logo/logo.png
-appVersion: 1.12.9
+appVersion: 1.17.0
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -29,11 +29,11 @@ annotations:
     - name: curl
       image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
     - name: cert-manager-cainjector
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.12.9
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.17.0
     - name: cert-manager-ctl
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.12.9
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.14.7
     - name: cert-manager-controller
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.12.9
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.17.0
     - name: cert-manager-webhook
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.12.9
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-webhook:v1.17.0
   artifacthub.io/license: MIT

--- a/charts/cray-certmanager/Chart.yaml
+++ b/charts/cray-certmanager/Chart.yaml
@@ -30,8 +30,8 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl:7.80.0
     - name: cert-manager-cainjector
       image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-cainjector:v1.17.0
-    - name: cert-manager-ctl
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-ctl:v1.14.7
+    - name: cert-manager-startupapicheck
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-startupapicheck:v1.17.0
     - name: cert-manager-controller
       image: artifactory.algol60.net/csm-docker/stable/quay.io/jetstack/cert-manager-controller:v1.17.0
     - name: cert-manager-webhook

--- a/charts/cray-certmanager/templates/wait-jobs.yaml
+++ b/charts/cray-certmanager/templates/wait-jobs.yaml
@@ -27,4 +27,4 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'SLEEP=10; ITER=90; for i in `seq 1 $ITER`; do curl -ks https://{{ index .Values "cert-manager" "webhook" "serviceName" }}.{{ .Release.Namespace }}.svc; [ $? -eq 0 ] && break; echo "[$i] unable to connect to cert-manager webhook svc, sleeping $SLEEP"; sleep $SLEEP; done'
+            - 'SLEEP=10; ITER=90; for i in `seq 1 $ITER`; do curl -ks https://{{ .Values.webhookServiceName.serviceName }}.{{ .Release.Namespace }}.svc; [ $? -eq 0 ] && break; echo "[$i] unable to connect to cert-manager webhook svc, sleeping $SLEEP"; sleep $SLEEP; done'

--- a/charts/cray-certmanager/values.yaml
+++ b/charts/cray-certmanager/values.yaml
@@ -83,9 +83,9 @@ cert-manager:
       "sidecar.istio.io/inject": "false"
     image:
       registry: artifactory.algol60.net
-      repository: csm-docker/stable/quay.io/jetstack/cert-manager-ctl
+      repository: csm-docker/stable/quay.io/jetstack/cert-manager-startupapicheck
 # Not actively ran just used in a k8s job to upgrade existing resources.
-ctl:
+startupapicheck:
   image:
     registry: artifactory.algol60.net
-    repository: csm-docker/stable/quay.io/jetstack/cert-manager-ctl
+    repository: csm-docker/stable/quay.io/jetstack/cert-manager-startupapicheck

--- a/charts/cray-certmanager/values.yaml
+++ b/charts/cray-certmanager/values.yaml
@@ -9,6 +9,8 @@ curl:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
     tag: 7.80.0
     pullPolicy: IfNotPresent
+webhookServiceName:
+  serviceName: cray-certmanager-cert-manager-webhook
 cert-manager:
   installCRDs: true
 
@@ -59,7 +61,6 @@ cert-manager:
                     values:
                       - webhook
               topologyKey: kubernetes.io/hostname
-    serviceName: cray-certmanager-cert-manager-webhook
   cainjector:
     image:
       registry: artifactory.algol60.net


### PR DESCRIPTION
## Summary and Scope

Upgrade cert-manager chart to use new v1.17.0 image for upgrading in CSM 1.7. Note that ctl has been changed to startupatpicheck, so I've updated the chart to account for that change, which shouldn't have any production impact that I'm aware of.

## Issues and Related PRs

* Backing issue [CASMPET-7368](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7368)
* Corresponding [image PR](https://github.com/Cray-HPE/container-images/pull/660)

## Testing

To validate correctness I tested with this certificate:

```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test-cert
  namespace: cert-manager
spec:
  dnsNames:
  - example.com
  secretName: test-cert-tls
  issuerRef:
    name: test-selfsigned-issuer
    kind: Issuer
```

And got this status after running `kubectl apply -f test-cert.yaml` and `kubectl describe certificate test-cert -n cert-manager`:

```
Status:
  Conditions:
    Last Transition Time:        2025-02-03T21:47:18Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      True
    Type:                        Issuing
    Last Transition Time:        2025-02-03T21:47:18Z
    Message:                     Issuing certificate as Secret does not exist
    Observed Generation:         1
    Reason:                      DoesNotExist
    Status:                      False
    Type:                        Ready
```

### Tested on:

  * Virtual Shasta

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

