### PR TITLE
CASMPET-7418: Disable PSPs for k8s 1.32 compatibility

### DIFF
--- a/charts/cray-certmanager/Chart.yaml
+++ b/charts/cray-certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-certmanager
-version: 0.9.1
+version: 0.9.2
 description: Support for managing PKI certificates and associated key material inside k8s
 keywords:
   - cert-manager

--- a/charts/cray-certmanager/values.yaml
+++ b/charts/cray-certmanager/values.yaml
@@ -20,7 +20,7 @@ cert-manager:
       # Create PodSecurityPolicy for cert-manager.
       #
       # Note that PodSecurityPolicy was deprecated in Kubernetes 1.21 and removed in Kubernetes 1.25.
-      enabled: true
+      enabled: false
       # Configure the PodSecurityPolicy to use AppArmor.
       useAppArmor: true
 


### PR DESCRIPTION
## Summary and Scope

After attempting the upgrades of my components with k8s 1.32 on Wasp, I uncovered some outstanding PSPs that need to be removed in order to make those 1.32 compatible.

## Issues and Related PRs

* Related to [CASMPET-7418](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7418)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp` with 1.32

### Test description:

Before:
```
# helm upgrade -n cert-manager cray-certmanager ./cray-certmanager-0.9.1.tgz -f values.yaml
Error: UPGRADE FAILED: [resource mapping not found for name: "cray-certmanager-cert-manager-cainjector" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "cray-certmanager-cert-manager" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "cray-certmanager-cert-manager-webhook" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first]
```

After:
```
# helm upgrade -n cert-manager cray-certmanager ./cray-certmanager-0.9.1.tgz -f values.yaml
Release "cray-certmanager" has been upgraded. Happy Helming!
NAME: cray-certmanager
LAST DEPLOYED: Wed Mar 12 16:37:56 2025
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Installed cert-manager as part of cray-certmanager.
```

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

